### PR TITLE
fix(ci/cd): resolve invalid substitution error in tag creation step

### DIFF
--- a/.github/workflows/mini-shop.yml
+++ b/.github/workflows/mini-shop.yml
@@ -113,7 +113,7 @@ jobs:
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           CURRENT_DATE=$(date -u +'%Y.%m.%d')
-          TAG_NAME="v${CURRENT_DATE}-${github.run_number}"
+          TAG_NAME="v${CURRENT_DATE}-${{ github.run_number }}"
           git tag $TAG_NAME
           git push origin $TAG_NAME
           echo "Created and pushed tag: $TAG_NAME"


### PR DESCRIPTION
- Fixes issue with `${github.run_number}` being improperly expanded in shell.
- Corrected interpolation to use GitHub Actions syntax for `github.run_number`.
- Ensures the tag creation step runs successfully in the main branch pipeline.